### PR TITLE
Improve `dmsg` logging

### DIFF
--- a/client.go
+++ b/client.go
@@ -218,18 +218,18 @@ func (c *ClientConn) Serve(ctx context.Context, accept chan<- *Transport) (err e
 				defer c.wg.Done()
 				initPK, err := c.handleRequestFrame(accept, id, p)
 				if err != nil {
-					log.WithField("remoteClient", initPK).WithError(err).Infoln("Rejected [REQUEST]")
+					log.WithField("remoteClient", initPK).WithError(err).Debugln("Rejected [REQUEST]")
 					if isWriteError(err) || err == ErrClientClosed {
 						err := c.Close()
 						log.WithError(err).Warn("ClosingConnection")
 					}
 					return
 				}
-				log.WithField("remoteClient", initPK).Infoln("Accepted [REQUEST]")
+				log.WithField("remoteClient", initPK).Debugln("Accepted [REQUEST]")
 			}(log)
 
 		default:
-			log.Infof("Ignored [%s]: No transport of given ID.", ft)
+			log.Debugf("Ignored [%s]: No transport of given ID.", ft)
 			if ft != CloseType {
 				if err := writeCloseFrame(c.Conn, id, 0); err != nil {
 					return err

--- a/client.go
+++ b/client.go
@@ -218,14 +218,14 @@ func (c *ClientConn) Serve(ctx context.Context, accept chan<- *Transport) (err e
 				defer c.wg.Done()
 				initPK, err := c.handleRequestFrame(accept, id, p)
 				if err != nil {
-					log.WithField("remoteClient", initPK).WithError(err).Debugln("Rejected [REQUEST]")
+					log.WithField("remoteClient", initPK).WithError(err).Infoln("Rejected [REQUEST]")
 					if isWriteError(err) || err == ErrClientClosed {
 						err := c.Close()
 						log.WithError(err).Warn("ClosingConnection")
 					}
 					return
 				}
-				log.WithField("remoteClient", initPK).Debugln("Accepted [REQUEST]")
+				log.WithField("remoteClient", initPK).Infoln("Accepted [REQUEST]")
 			}(log)
 
 		default:

--- a/server.go
+++ b/server.go
@@ -134,24 +134,24 @@ func (c *ServerConn) Serve(ctx context.Context, getConn getConnFunc) (err error)
 			_, why, ok := c.handleRequest(ctx, getConn, id, p)
 			cancel()
 			if !ok {
-				log.Infoln("FrameRejected: Erroneous request or unresponsive dstClient.")
+				log.Debugln("FrameRejected: Erroneous request or unresponsive dstClient.")
 				if err := c.delChan(id, why); err != nil {
 					return err
 				}
 			}
-			log.Infoln("FrameForwarded")
+			log.Debugln("FrameForwarded")
 
 		case AcceptType, FwdType, AckType, CloseType:
 			next, why, ok := c.forwardFrame(ft, id, p)
 			if !ok {
-				log.Infoln("FrameRejected: Failed to forward to dstClient.")
+				log.Debugln("FrameRejected: Failed to forward to dstClient.")
 				// Delete channel (and associations) on failure.
 				if err := c.delChan(id, why); err != nil {
 					return err
 				}
 				continue
 			}
-			log.Infoln("FrameForwarded")
+			log.Debugln("FrameForwarded")
 
 			// On success, if Close frame, delete the associations.
 			if ft == CloseType {
@@ -160,7 +160,7 @@ func (c *ServerConn) Serve(ctx context.Context, getConn getConnFunc) (err error)
 			}
 
 		default:
-			log.Infoln("FrameRejected: Unknown frame type.")
+			log.Debugln("FrameRejected: Unknown frame type.")
 			// Unknown frame type.
 			return errors.New("unknown frame of type received")
 		}


### PR DESCRIPTION
Fixes #10 

 Changes:	
- Change logging level when receiving a frame

How to test this PR:
Run tests with `debug` logging level