### PR TITLE
Improve '.Close()' methods for all structures. 

### DIFF
--- a/client.go
+++ b/client.go
@@ -256,14 +256,18 @@ func (c *ClientConn) DialTransport(ctx context.Context, clientPK cipher.PubKey) 
 }
 
 func (c *ClientConn) close() (closed bool) {
+	if c == nil {
+		return false
+	}
 	c.once.Do(func() {
 		closed = true
 		c.log.WithField("remoteServer", c.remoteSrv).Infoln("ClosingConnection")
 		close(c.done)
 		c.mx.Lock()
 		for _, tp := range c.tps {
+			// Nil check is required here to keep 8192 running goroutines limit in tests with -race flag.
 			if tp != nil {
-				go tp.Close() //nolint:errcheck
+				go tp.Close() // nolint:errcheck
 			}
 		}
 		_ = c.Conn.Close() //nolint:errcheck
@@ -274,6 +278,9 @@ func (c *ClientConn) close() (closed bool) {
 
 // Close closes the connection to dms_server.
 func (c *ClientConn) Close() error {
+	if c == nil {
+		return nil
+	}
 	if c.close() {
 		c.wg.Wait()
 	}
@@ -539,6 +546,10 @@ func (c *Client) Type() string {
 // Close closes the dms_client and associated connections.
 // TODO(evaninjin): proper error handling.
 func (c *Client) Close() error {
+	if c == nil {
+		return nil
+	}
+
 	c.once.Do(func() {
 		close(c.done)
 		for {

--- a/client.go
+++ b/client.go
@@ -278,9 +278,6 @@ func (c *ClientConn) close() (closed bool) {
 
 // Close closes the connection to dms_server.
 func (c *ClientConn) Close() error {
-	if c == nil {
-		return nil
-	}
 	if c.close() {
 		c.wg.Wait()
 	}

--- a/noise/net.go
+++ b/noise/net.go
@@ -78,6 +78,9 @@ func (d *RPCClientDialer) Run(srv *rpc.Server, retry time.Duration) error {
 
 // Close closes the handler.
 func (d *RPCClientDialer) Close() (err error) {
+	if d == nil {
+		return nil
+	}
 	d.mu.Lock()
 	if d.done != nil {
 		close(d.done)

--- a/noise/net_test.go
+++ b/noise/net_test.go
@@ -52,10 +52,8 @@ func TestRPCClientDialer(t *testing.T) {
 	}
 
 	teardown := func() {
-		if l != nil {
-			require.NoError(t, l.Close())
-			l = nil
-		}
+		require.NoError(t, l.Close())
+		l = nil
 	}
 
 	t.Run("RunRetry", func(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -293,6 +293,10 @@ func (s *Server) connCount() int {
 
 // Close closes the dms_server.
 func (s *Server) Close() (err error) {
+	if s == nil {
+		return nil
+	}
+
 	if err = s.lis.Close(); err != nil {
 		return err
 	}

--- a/transport.go
+++ b/transport.go
@@ -83,6 +83,10 @@ func (tp *Transport) serve() (started bool) {
 // 3. Our worry now, is writing to `inCh`/`bufCh` AFTER they have been closed.
 // 4. But as, under the mutexes protecting `inCh`/`bufCh`, checking `done` comes first, and we know that `done` is closed before `inCh`/`bufCh`, we can guarantee that it avoids writing to closed chan.
 func (tp *Transport) close() (closed bool) {
+	if tp == nil {
+		return false
+	}
+
 	tp.doneOnce.Do(func() {
 		closed = true
 
@@ -105,6 +109,10 @@ func (tp *Transport) close() (closed bool) {
 
 // Close closes the dmsg_tp.
 func (tp *Transport) Close() error {
+	if tp == nil {
+		return nil
+	}
+
 	if tp.close() {
 		_ = writeFrame(tp.Conn, MakeFrame(CloseType, tp.id, []byte{0})) //nolint:errcheck
 	}

--- a/transport.go
+++ b/transport.go
@@ -109,10 +109,6 @@ func (tp *Transport) close() (closed bool) {
 
 // Close closes the dmsg_tp.
 func (tp *Transport) Close() error {
-	if tp == nil {
-		return nil
-	}
-
 	if tp.close() {
 		_ = writeFrame(tp.Conn, MakeFrame(CloseType, tp.id, []byte{0})) //nolint:errcheck
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -40,4 +40,10 @@ func TestTransport_close(t *testing.T) {
 		_, ok := <-tr.done
 		assert.False(t, ok)
 	})
+
+	t.Run("No panic with nil pointer receiver", func(t *testing.T) {
+		var tr1, tr2 *Transport
+		assert.Nil(t, tr1.Close())
+		assert.False(t, tr2.close())
+	})
 }


### PR DESCRIPTION
Fixes #12

 Changes:	
-	Check if method receiver is nil in close() methods

