### PR TITLE
Use maps instead of arrays in structures

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"sync"
 	"time"
@@ -44,7 +43,7 @@ type ClientConn struct {
 	nextInitID uint16
 
 	// Transports: map of transports to remote dms_clients (key: tp_id, val: transport).
-	tps [math.MaxUint16 + 1]*Transport
+	tps map[uint16]*Transport
 	mx  sync.RWMutex // to protect tps
 
 	done chan struct{}
@@ -60,6 +59,7 @@ func NewClientConn(log *logging.Logger, conn net.Conn, local, remote cipher.PubK
 		local:      local,
 		remoteSrv:  remote,
 		nextInitID: randID(true),
+		tps:        make(map[uint16]*Transport),
 		done:       make(chan struct{}),
 	}
 	cc.wg.Add(1)

--- a/ioutil/ack_waiter.go
+++ b/ioutil/ack_waiter.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"io"
-	"math"
 	"sync"
 )
 
@@ -30,8 +29,15 @@ func (s Uint16Seq) Encode() []byte {
 // Uint16AckWaiter implements acknowledgement-waiting logic (with uint16 sequences).
 type Uint16AckWaiter struct {
 	nextSeq Uint16Seq
-	waiters [math.MaxUint16 + 1]chan struct{}
+	waiters map[Uint16Seq]chan struct{}
 	mx      sync.RWMutex
+}
+
+// NewUint16AckWaiter creates a new Uint16AckWaiter
+func NewUint16AckWaiter() Uint16AckWaiter {
+	return Uint16AckWaiter{
+		waiters: make(map[Uint16Seq]chan struct{}),
+	}
 }
 
 // RandSeq should only be run once on startup. It is not thread-safe.

--- a/ioutil/ack_waiter_test.go
+++ b/ioutil/ack_waiter_test.go
@@ -14,7 +14,7 @@ func TestUint16AckWaiter_Wait(t *testing.T) {
 	// each concurrent call to 'Uint16AckWaiter.Wait()' is met with
 	// multiple concurrent calls to 'Uint16AckWaiter.Done()' with the same seq.
 	t.Run("ensure_no_race_conditions", func(*testing.T) {
-		w := new(ioutil.Uint16AckWaiter)
+		w := ioutil.NewUint16AckWaiter()
 		defer w.StopAll()
 
 		seqChan := make(chan ioutil.Uint16Seq)

--- a/server.go
+++ b/server.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net"
 	"sync"
 	"time"
@@ -42,13 +41,19 @@ type ServerConn struct {
 	remoteClient cipher.PubKey
 
 	nextRespID uint16
-	nextConns  [math.MaxUint16 + 1]*NextConn
+	nextConns  map[uint16]*NextConn
 	mx         sync.RWMutex
 }
 
 // NewServerConn creates a new connection from the perspective of a dms_server.
 func NewServerConn(log *logging.Logger, conn net.Conn, remoteClient cipher.PubKey) *ServerConn {
-	return &ServerConn{log: log, Conn: conn, remoteClient: remoteClient, nextRespID: randID(false)}
+	return &ServerConn{
+		log:          log,
+		Conn:         conn,
+		remoteClient: remoteClient,
+		nextRespID:   randID(false),
+		nextConns:    make(map[uint16]*NextConn),
+	}
 }
 
 func (c *ServerConn) delNext(id uint16) {

--- a/server_test.go
+++ b/server_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"math/rand"
 	"net"
 	"os"
@@ -48,7 +47,7 @@ func TestServerConn_AddNext(t *testing.T) {
 
 	pk, _ := cipher.GenerateKeyPair()
 
-	var fullNextConns [math.MaxUint16 + 1]*NextConn
+	fullNextConns := make(map[uint16]*NextConn)
 	fullNextConns[1] = &NextConn{}
 	for i := uint16(3); i != 1; i += 2 {
 		fullNextConns[i] = &NextConn{}
@@ -69,6 +68,7 @@ func TestServerConn_AddNext(t *testing.T) {
 				remoteClient: pk,
 				log:          logging.MustGetLogger("ServerConn"),
 				nextRespID:   1,
+				nextConns:    map[uint16]*NextConn{},
 			},
 			ctx: context.Background(),
 			want: want{
@@ -81,7 +81,7 @@ func TestServerConn_AddNext(t *testing.T) {
 				remoteClient: pk,
 				log:          logging.MustGetLogger("ServerConn"),
 				nextRespID:   1,
-				nextConns: [math.MaxUint16 + 1]*NextConn{
+				nextConns: map[uint16]*NextConn{
 					1: {},
 				},
 			},
@@ -129,6 +129,7 @@ func TestServerConn_AddNext(t *testing.T) {
 		log:          logging.MustGetLogger("ServerConn"),
 		remoteClient: pk,
 		nextRespID:   1,
+		nextConns:    map[uint16]*NextConn{},
 	}
 
 	var wg sync.WaitGroup

--- a/transport.go
+++ b/transport.go
@@ -50,18 +50,19 @@ type Transport struct {
 // NewTransport creates a new dms_tp.
 func NewTransport(conn net.Conn, log *logging.Logger, local, remote cipher.PubKey, id uint16, doneFunc func(id uint16)) *Transport {
 	tp := &Transport{
-		Conn:     conn,
-		log:      log,
-		id:       id,
-		local:    local,
-		remote:   remote,
-		inCh:     make(chan Frame),
-		ackBuf:   make([]byte, 0, tpAckCap),
-		buf:      make(net.Buffers, 0, tpBufFrameCap),
-		bufCh:    make(chan struct{}, 1),
-		serving:  make(chan struct{}),
-		done:     make(chan struct{}),
-		doneFunc: doneFunc,
+		Conn:      conn,
+		log:       log,
+		id:        id,
+		local:     local,
+		remote:    remote,
+		inCh:      make(chan Frame),
+		ackWaiter: ioutil.NewUint16AckWaiter(),
+		ackBuf:    make([]byte, 0, tpAckCap),
+		buf:       make(net.Buffers, 0, tpBufFrameCap),
+		bufCh:     make(chan struct{}, 1),
+		serving:   make(chan struct{}),
+		done:      make(chan struct{}),
+		doneFunc:  doneFunc,
 	}
 	if err := tp.ackWaiter.RandSeq(); err != nil {
 		log.Fatalln("failed to set ack_waiter seq:", err)


### PR DESCRIPTION
Fixes #14 

 Changes:	
-	Use maps instead of arrays in structures to reduce memory usage
