### PR TITLE
Improve logic of various components.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install-linters: ## Install linters
 	${OPTS} go get -u golang.org/x/tools/cmd/goimports
 
 format: ## Formats the code. Must have goimports installed (use make install-linters).
-	${OPTS} goimports -w -local github.com/skycoin/dmsg ./...
+	${OPTS} goimports -w -local github.com/skycoin/dmsg .
 
 dep: ## Sorts dependencies
 	${OPTS} go mod download

--- a/client.go
+++ b/client.go
@@ -574,7 +574,7 @@ func (c *Client) Close() error {
 			select {
 			case <-c.accept:
 			default:
-				close(c.accept) // TODO: data race.
+				close(c.accept)
 				return
 			}
 		}

--- a/transport.go
+++ b/transport.go
@@ -39,6 +39,7 @@ type Transport struct {
 	bufCh     chan struct{}          // chan for indicating whether this is a new FWD frame
 	bufSize   int                    // keeps track of the total size of 'buf'
 	bufMx     sync.Mutex             // protects fields responsible for handling FWD and ACK frames
+	rMx       sync.Mutex             // TODO: (WORKAROUND) concurrent reads seem problematic right now.
 
 	serving     chan struct{}   // chan which closes when serving begins
 	servingOnce sync.Once       // ensures 'serving' only closes once
@@ -295,7 +296,8 @@ func (tp *Transport) Serve() {
 				}
 
 				// add payload to 'buf'
-				tp.buf = append(tp.buf, p[2:])
+				pay := p[2:]
+				tp.buf = append(tp.buf, pay)
 
 				// notify of new data via 'bufCh' (only if not closed)
 				if !tp.IsClosed() {
@@ -340,6 +342,9 @@ func (tp *Transport) Serve() {
 func (tp *Transport) Read(p []byte) (n int, err error) {
 	<-tp.serving
 
+	tp.rMx.Lock()
+	defer tp.rMx.Unlock()
+
 startRead:
 	tp.bufMx.Lock()
 	n, err = tp.buf.Read(p)
@@ -354,14 +359,16 @@ startRead:
 	}
 	tp.bufMx.Unlock()
 
-	if tp.IsClosed() {
+	if n > 0 || len(p) == 0 {
+		if !tp.IsClosed() {
+			err = nil
+		}
 		return n, err
 	}
-	if n > 0 || len(p) == 0 {
-		return n, nil
-	}
 
-	<-tp.bufCh
+	if _, ok := <-tp.bufCh; !ok {
+		return n, err
+	}
 	goto startRead
 }
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -53,7 +53,7 @@ func TestTransport_close(t *testing.T) {
 
 	t.Run("No panic with nil pointer receiver", func(t *testing.T) {
 		var tr1, tr2 *Transport
-		assert.Nil(t, tr1.Close())
+		assert.NoError(t, tr1.Close())
 		assert.False(t, tr2.close())
 	})
 }


### PR DESCRIPTION
## Changes

**Makefile:**
- Fixed `make format` target.

**`dmsg.Client`:**
- Fixed possible *write on closed chan* panics.
- Fixed possible data race when closing `c.accept` chan.
- Added new test to test whether closing a `dmsg.Transport` directly after a `Write` can result in a successful read from the other edge.

**`dmsg.Server`:**
- Fix incorrect behavior where elements of the `c.netConns` map is set to nil instead of being deleted.
- Improved behavior when a `dmsg.Client` is disconnected from the `dmsg.Server`:
    - New logic is in place to enforce transports are closed between the `dmsg.Client` in question and other `dmsg.Client`s.
    - New logic is in place to enforce that we don't close underlying connection when there is no need, or may interfere with the rest of the closing logic (e.g. the aforementioned).

**`dmsg.Transport`**
- Added a mutex to ensure that two `Read()` calls do not happen concurrently. This is a temporary measure as it seems that concurrent reads may cause issues (although it is yet to be proven).
- Simplify logic of how `Read()` returns.
- Fix test: Use `assert.NoError()` when checking `error`, instead of using `assert.Nil()`.