### PR TITLE
Fix incorrect time format in a log entry

### DIFF
--- a/client.go
+++ b/client.go
@@ -158,7 +158,7 @@ func (c *Client) findServerEntries(ctx context.Context) ([]*disc.Entry, error) {
 				return nil, fmt.Errorf("dms_servers are not available: %s", err)
 			default:
 				retry := time.Second
-				c.log.WithError(err).Warnf("no dms_servers found: trying again in %d second...", retry)
+				c.log.WithError(err).Warnf("no dms_servers found: trying again in %v...", retry)
 				time.Sleep(retry)
 				continue
 			}


### PR DESCRIPTION
`Warnf` prints a number of nanoseconds with `%d` verb. Using `%v` outputs the duration using the format provided by the `time` package.